### PR TITLE
Add VPN IPSEC discovery and fix haState

### DIFF
--- a/includes/definitions/discovery/gaia.yaml
+++ b/includes/definitions/discovery/gaia.yaml
@@ -56,18 +56,6 @@ modules:
                         - { value: 1, descr: yes, graph: 1, generic: 0 }
                         - { value: 0, descr: no, graph: 0, generic: 2 }
                 -
-                    oid: haState
-                    num_oid: '.1.3.6.1.4.1.2620.1.5.6.{{ $index }}'
-                    index: 'haState.{{ $index }}'
-                    descr: 'Cluster member state'
-                    group: HA
-                    value: haState
-                    states:
-                        - { value: 1, descr: active , graph: 3, generic: 0 }
-                        - { value: 2, descr: standby, graph: 2, generic: 0 }
-                        - { value: 3, descr: 'active attention', graph: 1, generic: 1 }
-                        - { value: 0, descr: down, graph: 0, generic: 2 }
-                -
                     oid: haStatCode
                     num_oid: '.1.3.6.1.4.1.2620.1.5.101.{{ $index }}'
                     index: 'haStatCode.{{ $index }}'
@@ -79,6 +67,21 @@ modules:
                         - { value: 1, descr: Attention, graph: 1, generic: 3 }
                         - { value: 2, descr: Down, graph: 0, generic: 1 }
                 -
+                    oid: tunnelState
+                    num_oid: '.1.3.6.1.4.1.2620.500.9002.1.3.{{ $index }}'
+                    index: 'tunnelStateIndex.{{ $index }}'
+                    descr: "{{ $tunnelPeerObjName }} ({{ $tunnelPeerIpAddr }})"
+                    group: IPSEC VPN
+                    value: tunnelState
+                    states:
+                        - { value: 0, descr: Unknown, graph: 1, generic: 3 }
+                        - { value: 3, descr: Up, graph: 1, generic: 0 }
+                        - { value: 4, descr: Destroyed, graph: 1, generic: 3 }
+                        - { value: 129, descr: Idle, graph: 1, generic: 3 }
+                        - { value: 130, descr: Phase1, graph: 1, generic: 1 }
+                        - { value: 131, descr: Down, graph: 1, generic: 2 }
+                        - { value: 132, descr: Init, graph: 1, generic: 1 }                        
+                -                
                     oid: raidVolumeState
                     num_oid: '.1.3.6.1.4.1.2620.1.6.7.7.1.1.6.{{ $index }}'
                     index: 'raidVolumeState.{{ $index }}'


### PR DESCRIPTION
Adding VPN IPSEC Discovery and fix haState at creating https://github.com/librenms/librenms/pull/12821
haState does not work from yaml file because needs to Convert string value to integer LibreNMS value


DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
